### PR TITLE
Simplify __split_range

### DIFF
--- a/src/pregex/core/classes.py
+++ b/src/pregex/core/classes.py
@@ -712,17 +712,26 @@ class __Class(_pre.Pregex):
 
 
     @staticmethod
-    def __split_range(pattern: str) -> tuple[str, str]:
+    def __split_range(pattern: str) -> list[str]:
         '''
-        Splits the provided range pattern and returns result as a tuple \
-        containing the range's beginning and end.
+        Splits the provided range pattern and returns result as a list \
+        of length two where the first element is the range's beginning \
+        and the second element is the range's end. 
 
         :param str pattern: The pattern that is to be split.
 
-        :note: Provided characters within the range MUST NOT be escaped.
+        :note: The provided range pattern must be in the form of \
+            \\?.-\\?. where "\\?" specifies the option to escape the \
+            character within the range, and "." includes newlines.
         '''
 
-        return (pattern[0], pattern[2])
+        count = pattern.count("-")
+
+        if count == 1:
+            return pattern.split("-")
+        if count == 2:
+            return pattern.split("-", 1) if pattern[-1] == "-" else pattern.rsplit("-", 1)
+        return list("-", "-")
 
 
 class Any(__Class):

--- a/src/pregex/core/classes.py
+++ b/src/pregex/core/classes.py
@@ -722,15 +722,7 @@ class __Class(_pre.Pregex):
         :note: Provided characters within the range MUST NOT be escaped.
         '''
 
-        count = pattern.count("-")
-
-        if count == 1:
-            return pattern.split("-")
-        elif count == 2:
-            split_fun = pattern.split if pattern[-1] == "-" else pattern.rsplit
-            return split_fun("-", 1)
-        else:
-            return ("-", "-")
+        return (pattern[0], pattern[2])
 
 
 class Any(__Class):

--- a/src/pregex/core/classes.py
+++ b/src/pregex/core/classes.py
@@ -731,7 +731,7 @@ class __Class(_pre.Pregex):
             return pattern.split("-")
         if count == 2:
             return pattern.split("-", 1) if pattern[-1] == "-" else pattern.rsplit("-", 1)
-        return list("-", "-")
+        return ["-", "-"]
 
 
 class Any(__Class):


### PR DESCRIPTION
This PR simplifies the `__Class.__split_range` static method.

`__Class.__split_range` should throw an error if `pattern` is not of valid structure. A check for this should probably be done before returning, but I have omitted this part at this point in time as I have not read enough of the codebase to know if this check is already being done somewhere else, so I am waiting for your feedback on that.

The previous implementation didn't return a tuple when `count == 1` or `count ==2` (it would return a list of length 2), going against the function header. In addition, this method really just wants the first and last character in the `pattern` string, so there is no need to break it up into 3 cases. Also, the previous implementation would return `tuple("-", "-")` even in the case of invalid input such as `pattern="foobar"`. 